### PR TITLE
Apple store badge on mobile

### DIFF
--- a/src/ch/index.html
+++ b/src/ch/index.html
@@ -102,7 +102,7 @@
       <a href="https://play.google.com/store/apps/details?id=org.getlantern.lantern" class="google-badge on-mobile">
         <img src="../static/images/badge_google_cn.png" alt="">
       </a>
-      <a href="https://apps.apple.com/app/id1457872372?l=zh_cn" class="google-badge">
+      <a href="https://apps.apple.com/app/id1457872372?l=zh_cn" class="google-badge on-mobile">
         <img src="../static/images/badge_apple_cn.png" alt="">
       </a>
     </div>

--- a/src/ch/index.html
+++ b/src/ch/index.html
@@ -102,6 +102,9 @@
       <a href="https://play.google.com/store/apps/details?id=org.getlantern.lantern" class="google-badge on-mobile">
         <img src="../static/images/badge_google_cn.png" alt="">
       </a>
+      <a href="https://apps.apple.com/app/id1457872372?l=zh_cn" class="google-badge">
+        <img src="../static/images/badge_apple_cn.png" alt="">
+      </a>
     </div>
     
   </div>  

--- a/src/en/index.html
+++ b/src/en/index.html
@@ -94,6 +94,9 @@
       <a href="https://play.google.com/store/apps/details?id=org.getlantern.lantern" class="google-badge on-mobile">
         <img src="../static/images/badge_google_en.png" alt="">
       </a>
+      <a href="https://apps.apple.com/app/id1457872372?l=zh_cn" class="google-badge">
+        <img src="../static/images/badge_apple_cn.png" alt="">
+      </a>
     </div>
 
   </div>

--- a/src/en/index.html
+++ b/src/en/index.html
@@ -94,7 +94,7 @@
       <a href="https://play.google.com/store/apps/details?id=org.getlantern.lantern" class="google-badge on-mobile">
         <img src="../static/images/badge_google_en.png" alt="">
       </a>
-      <a href="https://apps.apple.com/app/id1457872372?l=zh_cn" class="google-badge">
+      <a href="https://apps.apple.com/app/id1457872372?l=zh_cn" class="google-badge on-mobile">
         <img src="../static/images/badge_apple_cn.png" alt="">
       </a>
     </div>

--- a/src/faq/index.html
+++ b/src/faq/index.html
@@ -184,6 +184,9 @@ To keep our free version running, we implemented a bandwidth limitation of 500 M
     <a href="https://play.google.com/store/apps/details?id=org.getlantern.lantern" class="google-badge">
       <img src="../static/images/badge_google_en.png" alt="">
     </a>
+    <a href="https://apps.apple.com/app/id1457872372?l=zh_cn" class="google-badge">
+      <img src="../static/images/badge_apple_cn.png" alt="">
+    </a>
   </div>  
 </section>
 


### PR DESCRIPTION
Here's how it looks like now. I changed the Groove widget from the "NEED HELP?" rectangle button to this circle button with question mark, to avoid overriding the Apple Store badge. @oxtoacart do you think it is okay or not for Apple reviewer?

![image](https://user-images.githubusercontent.com/22091642/74618256-cc16ca80-50e5-11ea-9df3-b853b6dbe825.png)
